### PR TITLE
Updated polling interval

### DIFF
--- a/index.js
+++ b/index.js
@@ -9,7 +9,7 @@ class GitHub extends q.DesktopApp {
 
   constructor() {
     super();
-    this.pollingInterval = 60000 * 5; // every 5 min
+    this.pollingInterval = 60000 * 0.25; // every 15 sec
   }
   /**
    * Delete all previous signals


### PR DESCRIPTION
When you mark a notification as "read" on GitHub, it takes an unacceptably long time for the keyboard to reflect the changes you made. GitHub's rate-limiting: https://developer.github.com/apps/building-github-apps/understanding-rate-limits-for-github-apps/ allows for more frequent updates, so I set the polling interval to be 15 sec. This allows for a more seamless use of this applet.

@fabiendv Is there a way to add a custom button to the applet popup?

I'm thinking of a button that will allow a user to mark everything as read and refresh the keyboard status at once. 